### PR TITLE
Fix undefined issue on Android

### DIFF
--- a/be.grincheux.tiBrowser/controllers/widget.js
+++ b/be.grincheux.tiBrowser/controllers/widget.js
@@ -28,7 +28,9 @@ function pageLoaded() {
 	loadedTimeout = setTimeout(doLoaded, 500); // Set a timeout so redirects are not taken into account.
 }
 function doLoaded() {
-	$.showActions.enabled = true;
+	if(OS_IOS) {
+		$.showActions.enabled = true;
+	}
 	if (browsing_direction == ""
 	&& $.webView.url != history[history_position]
 	&& $.webView.evalJS("document.querySelector('body').innerHTML").length) { // Update history only if a link has been clicked, not on back, previous or refresh action.


### PR DESCRIPTION
$.showActions is available only on iOS, so here I'm checking to make sure we're on iOS before we set the enabled property to true. 

This prevents the following runtime error on Android:
Location:
[91,31] alloy/widgets/be.grincheux.tiBrowser/controllers/widget.js

Message:
Uncaught TypeError: Cannot set property 'enabled' of undefined

Source:
$showActions.enabled = true;
